### PR TITLE
Add help command for users

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from importlib import reload
 intents = nextcord.Intents.default()
 intents.message_content = True
 
-use_debug_mode = True
+use_debug_mode = False
 
 client = commands.Bot(command_prefix = '::<' if use_debug_mode else '<', intents = intents, help_command = None)
 

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from importlib import reload
 intents = nextcord.Intents.default()
 intents.message_content = True
 
-use_debug_mode = False
+use_debug_mode = True
 
 client = commands.Bot(command_prefix = '::<' if use_debug_mode else '<', intents = intents, help_command = None)
 
@@ -31,6 +31,37 @@ def is_owner(ctx: commands.Context) -> bool:
 async def on_ready() -> None:
     os.system('cls' if os.name == 'nt' else 'clear')
     print(f'\u001b[45;1m ** \u001b[0m Successfully logged in as: {client.user}')
+    
+    
+@client.command(name = 'help>')
+async def helper(ctx: commands.Context) -> None:
+    
+    help_embed = nextcord.Embed(
+        title = '', 
+        description = 'a Python Discord chat bot who can talk with you in English and Thai.', 
+        color = 0xd357fe
+    )
+    
+    help_embed.set_author(
+        name = 'Celestial#0135', 
+        icon_url = 'https://cdn.discordapp.com/app-icons/927573556961869825/b4b624c1cb68fa3a99a24a8e9942d2a5.png'
+    )
+    
+    help_embed.add_field(
+        name = 'How can you talk to me?', 
+        value = 'You can talk to me by simply type\n`<usr> Your messages` to send me a messages!', 
+        inline = False
+    )
+    
+    help_embed.add_field(
+        name = 'Development & Update', 
+        value = 'Follow the latest update at: \n**https://github.com/StrixzIV/Celestial**', 
+        inline = False
+    )
+    
+    help_embed.set_footer(text = '© 2022 MIT License - StrixzIV#6258, Peachpiggies#9229')
+    
+    await ctx.send(embed = help_embed)
     
 
 @client.command(name = 'usr>')


### PR DESCRIPTION
Here's the output of help command that I make:

<img width="433" alt="Screen Shot 2565-10-15 at 22 53 28" src="https://user-images.githubusercontent.com/46487993/196014386-1fc81d59-c9ec-42d1-861d-9edbca54309d.png">

Hope you would like it. @Peachpiggies 

Make sure to review my changes.