### PR TITLE
Add string template for bot responses

### DIFF
--- a/chat_response.py
+++ b/chat_response.py
@@ -2,15 +2,19 @@ import re
 import sys
 import json
 import random
+import string
 import pythainlp
 
 import datetime as dt
+from dateutil.relativedelta import relativedelta
 
 from time import perf_counter
 
 # check if python > 3.9
 if sys.version_info[0:2] < (3, 9):
     raise AssertionError('This project requires Python 3.9 or higher.')
+
+birthday = dt.datetime(2022, 1, 4)
 
 resp_dir = [
     './responses/responses.json',
@@ -144,6 +148,15 @@ def get_response(input_text: str, debug: bool = False) -> str:
     is_thai = detect_thai(split_text)
 
     response = check_all_msg(split_text, is_thai, dt.date.today())
+    
+    current_time = dt.datetime.now()
+    age = relativedelta(current_time, birthday).years
+    
+    if re.finditer(r'(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))', response, re.MULTILINE) != {}:
+        response = string.Template(response).substitute(
+            age = age,
+            time = current_time.strftime('%A, %d %B %Y - %H:%M:%S')
+        )
     
     end_timer = perf_counter()
 

--- a/chat_response.py
+++ b/chat_response.py
@@ -155,7 +155,8 @@ def get_response(input_text: str, debug: bool = False) -> str:
     if re.finditer(r'(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))', response, re.MULTILINE) != {}:
         response = string.Template(response).substitute(
             age = age,
-            time = current_time.strftime('%A, %d %B %Y - %H:%M:%S')
+            time = current_time.strftime('%H:%M:%S'),
+            timezone = current_time.astimezone().tzinfo
         )
     
     end_timer = perf_counter()

--- a/docs/chat_intents_guide.md
+++ b/docs/chat_intents_guide.md
@@ -80,7 +80,7 @@ A chat intent that outputs a cetrain message by combining datetime and keyword d
 * **date**: a date range for which the festival is held(For this example, the date range is January 1 to January 2.)
 * **month**: the month in which the festival is held.
 
-### Special variable
+## Special variable
 
 Special variables are variables that have a predefined with the data of the bot.
 
@@ -88,7 +88,7 @@ These special variables can be used in the response field of a JSON object to in
 
 Using special variables allows the chatbot to provide more relevant and personalized responses to the user, and can make the conversation feel more dynamic and interactive.
 
-**List of variables**
+### List of variables
 
 * `$age`: The number of years since the first commit (or "birthday" of the system).
 * `$time`: The current 24-hour local time in the format "HH:MM:SS" of the server running Celestial.

--- a/docs/chat_intents_guide.md
+++ b/docs/chat_intents_guide.md
@@ -79,3 +79,41 @@ A chat intent that outputs a cetrain message by combining datetime and keyword d
 * **required_word**: A list of words that must be typed in order for the response to occur.
 * **date**: a date range for which the festival is held(For this example, the date range is January 1 to January 2.)
 * **month**: the month in which the festival is held.
+
+### Special variable
+
+Special variables are variables that have a predefined with the data of the bot.
+
+These special variables can be used in the response field of a JSON object to include dynamic information in the chatbot's responses.
+
+Using special variables allows the chatbot to provide more relevant and personalized responses to the user, and can make the conversation feel more dynamic and interactive.
+
+**List of variables**
+
+* `$age`: The number of years since the first commit (or "birthday" of the system).
+* `$time`: The current 24-hour local time in the format "HH:MM:SS" of the server running Celestial.
+* `$timezone`: The local timezone of the server running Celestial.
+
+To implement these variables, you can use them in the response field of your JSON object, like this:
+
+```json
+"age": {
+    "response": [
+      "I'm $age year old now!"
+    ],
+    "list_of_words": ["how", "old", "are", "you"],
+    "is_single_response": false,
+    "required_word": ["old"]
+  }
+```
+
+```json
+"time": {
+    "response": [
+      "It's $time in my timezone now (UTC $timezone). How about you?"
+    ],
+    "list_of_words": ["what", "time"],
+    "is_single_response": false,
+    "required_word": ["time"]
+  }
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ flask-limiter>=2.7.0
 flask-restful>=0.3.9
 GitPython>=3.1.28
 waitress>=2.1.2
+python-dateutil>=2.8.2

--- a/responses/responses.json
+++ b/responses/responses.json
@@ -172,7 +172,9 @@
   },
 
   "age": {
-    "response": ["Gosh... you shouldn't ask a girl age."],
+    "response": [
+      "I'm $age year old now!"
+    ],
     "list_of_words": ["how", "old", "are", "you"],
     "is_single_response": false,
     "required_word": ["old"]
@@ -243,6 +245,15 @@
     "list_of_words": ["meet","you"],
     "is_single_response": false,
     "required_word": ["meet"]
+  },
+  
+  "time": {
+    "response": [
+      "It's $time in my timezone now. How about you?"
+    ],
+    "list_of_words": ["what", "time"],
+    "is_single_response": false,
+    "required_word": ["time"]
   }
 
 }

--- a/responses/responses.json
+++ b/responses/responses.json
@@ -249,7 +249,7 @@
   
   "time": {
     "response": [
-      "It's $time in my timezone now. How about you?"
+      "It's $time in my timezone now (UTC $timezone). How about you?"
     ],
     "list_of_words": ["what", "time"],
     "is_single_response": false,

--- a/responses/responses_th.json
+++ b/responses/responses_th.json
@@ -173,8 +173,10 @@
   },
 
   "age_th": {
-    "response": ["โถ่...คุณพี่ไม่ควรถามอายุผู้หญิงสิคะ"],
-    "list_of_words": ["อายุ", "เท่า", "ไหร่"],
+    "response": [
+      "ตอนนี้หนูอายุ $age ขวบแล้วค่ะ"
+    ],
+    "list_of_words": ["อายุ", "เท่าไหร่"],
     "is_single_response": false,
     "required_word": []
   },
@@ -231,6 +233,15 @@
       "คุณพี่ก็น่าจะรู้หนิว่าหนูเป็นบอท คุณพี่ควรถามคุณพ่อไม่ก็เพื่อนร่วมงานแกแทนที่จะถามหนูนะคะ"
     ],
     "list_of_words": ["เพลง"],
+    "is_single_response": false,
+    "required_word": []
+  },
+  
+  "time_th": {
+    "response": [
+      "ตอนนี้เวลา $time แล้วค่ะ"
+    ],
+    "list_of_words": ["เวลา", "กี่", "โมง"],
     "is_single_response": false,
     "required_word": []
   }


### PR DESCRIPTION
I added a string template system so you can add dynamic data to the string

Here's are the list of available variables
* `$age` year since the first commit(Birthday)
* `$time` 24-hours local time in format of "Hour-Minute-Secound" of the server running Celestial
* `$timezone` local timezone of the server running Celestial

Here's how you would implement these variable:

```json
"age": {
    "response": [
      "I'm $age year old now!"
    ],
    "list_of_words": ["how", "old", "are", "you"],
    "is_single_response": false,
    "required_word": ["old"]
  }
```

```json
"time": {
    "response": [
      "It's $time in my timezone now (UTC $timezone). How about you?"
    ],
    "list_of_words": ["what", "time"],
    "is_single_response": false,
    "required_word": ["time"]
  }
```

The result:
<img width="588" alt="Screen Shot 2566-01-09 at 08 03 28" src="https://user-images.githubusercontent.com/46487993/211229125-95f56869-0b43-4e41-a704-8559b19cde2c.png">
<img width="456" alt="Screen Shot 2566-01-09 at 08 03 49" src="https://user-images.githubusercontent.com/46487993/211229132-26304ee2-1578-4c79-b83a-660627102f29.png">
