### PR TITLE
Fix CLI Tester flags trailing whitespaces bug

### DIFF
--- a/cli_tester.py
+++ b/cli_tester.py
@@ -38,7 +38,7 @@ def read_input(message: str) -> None:
 while True:
     
     try:
-        inp = input('\u001b[47;1m #> \u001b[0m ')
+        inp = input('\u001b[47;1m #> \u001b[0m ').strip()
         read_input(inp)
         
     except KeyboardInterrupt:


### PR DESCRIPTION
A bug fix for #31 

I fixed this error by stripping out all trailing whitespaces from the input so it would detect the flag and execute the command 