### PR TITLE
Migrate all developers commands to slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to send your message to the bot.
 ## Dependencies & Tools
 
 This project requires Python 3.9 or higher.
-This project uses **[Nextcord](https://github.com/nextcord/nextcord)** as Discord API wrapper and **[PyThaiNLP](https://github.com/PyThaiNLP/pythainlp)** for word tokenizing.
+This project uses **[discord.py](https://github.com/Rapptz/discord.py)** as Discord API wrapper and **[PyThaiNLP](https://github.com/PyThaiNLP/pythainlp)** for word tokenizing.
 
 A list of dependencies can be found **[here](./requirements.txt)**.
 

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ client = commands.Bot(
     command_prefix = '::<!' if use_debug_mode else '<!', 
     intents = intents, 
     help_command = None,
-    activity = discord.Game(name = '<!help> for more info.')
+    activity = discord.Game(name = '/help for more info.')
 )
 
 def is_owner(interaction: discord.Interaction) -> bool:

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ async def on_message(message: discord.Message) -> None:
     await client.process_commands(message)
     
     
-@client.tree.command(name = 'help')
+@client.tree.command(name = 'help', description = 'Display a help message.')
 async def helper(interaction: discord.Interaction) -> None:
     
     help_embed = discord.Embed(
@@ -91,7 +91,7 @@ async def helper(interaction: discord.Interaction) -> None:
     await interaction.response.send_message(embed = help_embed)
     
     
-@client.tree.command(name = 'reload')
+@client.tree.command(name = 'reload', description = '*For developers only*')
 @commands.check(is_owner)
 async def reload_bot(interaction: discord.Interaction) -> None:
     
@@ -119,7 +119,7 @@ async def on_reload_error(interaction: discord.Interaction, error: commands.erro
     await interaction.response.send_message(embed=error_embed)
     
     
-@client.tree.command(name = 'pull')
+@client.tree.command(name = 'pull', description = '*For developers only*') 
 @commands.check(is_owner)
 async def pull(interaction: discord.Interaction) -> None:
     

--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
 import os
 import git 
-import nextcord
+import discord
 import chat_response
 from dotenv import load_dotenv
-from nextcord.ext import commands
+from discord.ext import commands
 from dotenv import load_dotenv
 from importlib import reload
 
-intents = nextcord.Intents.default()
+intents = discord.Intents.default()
 intents.message_content = True
 
 use_debug_mode = False
@@ -16,7 +16,7 @@ client = commands.Bot(
     command_prefix = '::<!' if use_debug_mode else '<!', 
     intents = intents, 
     help_command = None,
-    activity = nextcord.Game(name = '<!help> for more info.')
+    activity = discord.Game(name = '<!help> for more info.')
 )
 
 def is_owner(ctx: commands.Context) -> bool:
@@ -36,7 +36,7 @@ async def on_ready() -> None:
 
 
 @client.event
-async def on_message(message: nextcord.Message) -> None:
+async def on_message(message: discord.Message) -> None:
 
     if message.content.startswith('<usr>'):
         chat_message = message.content.split('<usr>')[1].strip()
@@ -48,7 +48,7 @@ async def on_message(message: nextcord.Message) -> None:
 @client.command(name = 'help>')
 async def helper(ctx: commands.Context) -> None:
     
-    help_embed = nextcord.Embed(
+    help_embed = discord.Embed(
         title = '', 
         description = 'a Python Discord chat bot who can talk with you in English and Thai.', 
         color = 0xd357fe
@@ -98,7 +98,7 @@ async def reload_bot(ctx: commands.Context) -> None:
 @reload_bot.error
 async def on_reload_error(ctx: commands.Context, error: commands.errors) -> None:
     
-    error_embed = nextcord.Embed(
+    error_embed = discord.Embed(
         title = '⚠️ Permission Error ⚠️', 
         description = 'Reload attempt from non-authorized user.', 
         color = 0xFF0000
@@ -129,7 +129,7 @@ async def pull(ctx: commands.Context) -> None:
 @pull.error
 async def on_pull_error(ctx: commands.Context, error: commands.errors) -> None:
     
-    error_embed = nextcord.Embed(
+    error_embed = discord.Embed(
         title = '⚠️ Permission Error ⚠️', 
         description = 'Pull attempt from non-authorized user.', 
         color = 0xFF0000

--- a/main.py
+++ b/main.py
@@ -30,7 +30,16 @@ def is_owner(ctx: commands.Context) -> bool:
 
 @client.event
 async def on_ready() -> None:
+    
     os.system('cls' if os.name == 'nt' else 'clear')
+    
+    try:
+        synced = await client.tree.sync()
+        print(f'\u001b[45;1m ** \u001b[0m Synced: {len(synced)} commands' if len(synced) != 1 else f'\u001b[45;1m ** \u001b[0m Synced: {len(synced)} command')
+        
+    except Exception as e:
+        print(f'\u001b[41;1m !! \u001b[0m Exception detected: \n{e}')
+    
     print(f'\u001b[45;1m ** \u001b[0m Status: {"Debug" if use_debug_mode else "Production"}')
     print(f'\u001b[45;1m ** \u001b[0m Successfully logged in as: {client.user}')
 

--- a/main.py
+++ b/main.py
@@ -19,13 +19,13 @@ client = commands.Bot(
     activity = discord.Game(name = '<!help> for more info.')
 )
 
-def is_owner(ctx: commands.Context) -> bool:
+def is_owner(interaction: discord.Interaction) -> bool:
     
     '''
         Check if the command user is authorized.
     '''
     
-    return ctx.author.id in moderator_ids
+    return interaction.user.id in moderator_ids
     
 
 @client.event
@@ -54,8 +54,8 @@ async def on_message(message: discord.Message) -> None:
     await client.process_commands(message)
     
     
-@client.command(name = 'help>')
-async def helper(ctx: commands.Context) -> None:
+@client.tree.command(name = 'help')
+async def helper(interaction: discord.Interaction) -> None:
     
     help_embed = discord.Embed(
         title = '', 
@@ -88,12 +88,12 @@ async def helper(ctx: commands.Context) -> None:
     
     help_embed.set_footer(text = '© 2022 MIT License - StrixzIV#6258, Peachpiggies#9229')
     
-    await ctx.send(embed = help_embed)
+    await interaction.response.send_message(embed = help_embed)
     
     
-@client.command(name = 'reload>')
+@client.tree.command(name = 'reload')
 @commands.check(is_owner)
-async def reload_bot(ctx: commands.Context) -> None:
+async def reload_bot(interaction: discord.Interaction) -> None:
     
     os.system('cls' if os.name == 'nt' else 'clear')
     print('\u001b[45;1m ** \u001b[0m Reloading...')
@@ -101,11 +101,13 @@ async def reload_bot(ctx: commands.Context) -> None:
     reload(chat_response)
     
     print('\u001b[45;1m ** \u001b[0m Chat module reload successfully!')
-    print(f'\u001b[45;1m ** \u001b[0m Reload command sended from {ctx.author}')
+    print(f'\u001b[45;1m ** \u001b[0m Reload command sended from {interaction.user}')
+    
+    await interaction.response.send_message('Reload completed!')
     
 
 @reload_bot.error
-async def on_reload_error(ctx: commands.Context, error: commands.errors) -> None:
+async def on_reload_error(interaction: discord.Interaction, error: commands.errors) -> None:
     
     error_embed = discord.Embed(
         title = '⚠️ Permission Error ⚠️', 
@@ -113,13 +115,13 @@ async def on_reload_error(ctx: commands.Context, error: commands.errors) -> None
         color = 0xFF0000
     )
     
-    print(f'\u001b[41;1m !! \u001b[0m Error: Reload attempt from {ctx.author} which is not an authorized user.')
-    await ctx.send(embed=error_embed)
+    print(f'\u001b[41;1m !! \u001b[0m Error: Reload attempt from {interaction.user} which is not an authorized user.')
+    await interaction.response.send_message(embed=error_embed)
     
     
-@client.command(name = 'pull>')
+@client.tree.command(name = 'pull')
 @commands.check(is_owner)
-async def pull(ctx: commands.Context) -> None:
+async def pull(interaction: discord.Interaction) -> None:
     
     print('\u001b[45;1m ** \u001b[0m Pulling from origin...')
     
@@ -132,11 +134,13 @@ async def pull(ctx: commands.Context) -> None:
     reload(chat_response)
     
     print('\u001b[45;1m ** \u001b[0m Chat module reload successfully!')
-    print(f'\u001b[45;1m ** \u001b[0m Pull command sended from {ctx.author}')
+    print(f'\u001b[45;1m ** \u001b[0m Pull command sended from {interaction.user}')
+    
+    await interaction.response.send_message('Pull completed!')
     
     
 @pull.error
-async def on_pull_error(ctx: commands.Context, error: commands.errors) -> None:
+async def on_pull_error(interaction: discord.Interaction, error: commands.errors) -> None:
     
     error_embed = discord.Embed(
         title = '⚠️ Permission Error ⚠️', 
@@ -144,8 +148,8 @@ async def on_pull_error(ctx: commands.Context, error: commands.errors) -> None:
         color = 0xFF0000
     )
     
-    print(f'\u001b[41;1m !! \u001b[0m Error: Pull attempt from {ctx.author} which is not an authorized user.')
-    await ctx.send(embed=error_embed)
+    print(f'\u001b[41;1m !! \u001b[0m Error: Pull attempt from {interaction.user} which is not an authorized user.')
+    await interaction.response.send_message(embed=error_embed)
     
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nextcord>=2.2.0
+discord>=2.1.0
 python-dotenv>=0.20.0
 pythainlp==3.1.0
 numpy>=1.23.0


### PR DESCRIPTION
I move all of developer commands such as `reload` and `pull` command into slash command to replace the deprecated prefix command and I also change the Discord API wrapper back to discord.py