### PR TITLE
Change chat API endpoint to '/chat-legacy'

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ def show_ready(port: int, debug: bool) -> None:
 
 @cross_origin()
 @limiter.limit('450/minute')
-@app.route('/celestial-api', methods = ['POST'])
+@app.route('/chat-legacy', methods = ['POST'])
 def send_response():
     
     body = request.get_json()

--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ def show_ready(port: int, debug: bool) -> None:
     info_log('Chat REST API ready!')
     info_log(f'Mode: {"Debug" if debug else "Production"}')
     info_log('Press ctrl+c to exit.')
-    info_log(f'API running on: http://localhost:{port}')
+    info_log(f'API running on: http://localhost:{port}/chat-legacy')
 
 
 @cross_origin()


### PR DESCRIPTION
A feature request from issue #43.